### PR TITLE
Performance on OutgoingPaymentList#index.

### DIFF
--- a/app/models/outgoing_payment_list.rb
+++ b/app/models/outgoing_payment_list.rb
@@ -51,9 +51,7 @@ class OutgoingPaymentList < Ekylibre::Record::Base
   acts_as_numbered
 
   protect(on: :destroy) do
-    self.payments.joins(journal_entry: :items).where('LENGTH(TRIM(journal_entry_items.bank_statement_letter)) > 0 OR journal_entry_items.state = ?', :closed).exists?
-    # JournalEntryItem.where(entry_id: payments.select(:journal_entry_id))
-    #                 .where('LENGTH(TRIM(bank_statement_letter)) > 0 OR state = ?', :closed).any?
+    payments.joins(journal_entry: :items).where('LENGTH(TRIM(journal_entry_items.bank_statement_letter)) > 0 OR journal_entry_items.state = ?', :closed).exists?
   end
 
   def to_sepa

--- a/app/models/outgoing_payment_list.rb
+++ b/app/models/outgoing_payment_list.rb
@@ -51,8 +51,9 @@ class OutgoingPaymentList < Ekylibre::Record::Base
   acts_as_numbered
 
   protect(on: :destroy) do
-    JournalEntryItem.where(entry_id: payments.select(:entry_id))
-                    .where('LENGTH(TRIM(bank_statement_letter)) > 0 OR state = ?', :closed).any?
+    self.payments.joins(journal_entry: :items).where('LENGTH(TRIM(journal_entry_items.bank_statement_letter)) > 0 OR journal_entry_items.state = ?', :closed).exists?
+    # JournalEntryItem.where(entry_id: payments.select(:journal_entry_id))
+    #                 .where('LENGTH(TRIM(bank_statement_letter)) > 0 OR state = ?', :closed).any?
   end
 
   def to_sepa


### PR DESCRIPTION
Improved significantly performance on repeated #destroyable? querying on OutgoingPaymentLists to net a huge performance boost (from **229934ms** on rendering of 209 OutgoingPaymentLists to **1753ms**).