### PR TITLE
Add `codes` column to CultivableZones, Products and Activities

### DIFF
--- a/db/migrate/20170529203843_add_codes_to_cultivable_zones.rb
+++ b/db/migrate/20170529203843_add_codes_to_cultivable_zones.rb
@@ -1,0 +1,5 @@
+class AddCodesToCultivableZones < ActiveRecord::Migration
+  def change
+    add_column :cultivable_zones, :codes, :jsonb
+  end
+end

--- a/db/migrate/20170529203843_add_codes_to_cultivable_zones.rb
+++ b/db/migrate/20170529203843_add_codes_to_cultivable_zones.rb
@@ -1,5 +1,0 @@
-class AddCodesToCultivableZones < ActiveRecord::Migration
-  def change
-    add_column :cultivable_zones, :codes, :jsonb
-  end
-end

--- a/db/migrate/20170530002312_add_codes_to_cultivable_zones_land_parcels_and_activities.rb
+++ b/db/migrate/20170530002312_add_codes_to_cultivable_zones_land_parcels_and_activities.rb
@@ -1,0 +1,7 @@
+class AddCodesToCultivableZonesLandParcelsAndActivities < ActiveRecord::Migration
+  def change
+    add_column :cultivable_zones, :codes, :jsonb
+    add_column :products, :codes, :jsonb
+    add_column :activities, :codes, :jsonb
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1794,8 +1794,7 @@ CREATE TABLE cultivable_zones (
     production_system_name character varying,
     soil_nature character varying,
     owner_id integer,
-    farmer_id integer,
-    codes jsonb
+    farmer_id integer
 );
 
 
@@ -17853,6 +17852,4 @@ INSERT INTO schema_migrations (version) VALUES ('20170415163650');
 INSERT INTO schema_migrations (version) VALUES ('20170421131536');
 
 INSERT INTO schema_migrations (version) VALUES ('20170425145302');
-
-INSERT INTO schema_migrations (version) VALUES ('20170529203843');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -294,7 +294,8 @@ CREATE TABLE activities (
     grading_sizes_unit_name character varying,
     production_system_name character varying,
     use_seasons boolean DEFAULT false,
-    use_tactics boolean DEFAULT false
+    use_tactics boolean DEFAULT false,
+    codes jsonb
 );
 
 
@@ -1794,7 +1795,8 @@ CREATE TABLE cultivable_zones (
     production_system_name character varying,
     soil_nature character varying,
     owner_id integer,
-    farmer_id integer
+    farmer_id integer,
+    codes jsonb
 );
 
 
@@ -5882,7 +5884,8 @@ CREATE TABLE products (
     origin_country character varying,
     origin_identification_number character varying,
     end_of_life_reason character varying,
-    originator_id integer
+    originator_id integer,
+    codes jsonb
 );
 
 
@@ -17852,4 +17855,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170415163650');
 INSERT INTO schema_migrations (version) VALUES ('20170421131536');
 
 INSERT INTO schema_migrations (version) VALUES ('20170425145302');
+
+INSERT INTO schema_migrations (version) VALUES ('20170530002312');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1794,7 +1794,8 @@ CREATE TABLE cultivable_zones (
     production_system_name character varying,
     soil_nature character varying,
     owner_id integer,
-    farmer_id integer
+    farmer_id integer,
+    codes jsonb
 );
 
 
@@ -17852,4 +17853,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170415163650');
 INSERT INTO schema_migrations (version) VALUES ('20170421131536');
 
 INSERT INTO schema_migrations (version) VALUES ('20170425145302');
+
+INSERT INTO schema_migrations (version) VALUES ('20170529203843');
 


### PR DESCRIPTION
Adds `codes` transcoding columns to Product, CultivableZones and Activities so we can be more flexible on third-party integration.