### PR TITLE
Progress's capabilities extension

### DIFF
--- a/lib/progress.rb
+++ b/lib/progress.rb
@@ -1,4 +1,6 @@
 class Progress
+  class ReadOnlyError < Exception; end;
+
   attr_reader :name
   attr_reader :id
 
@@ -17,7 +19,7 @@ class Progress
       @progresses[progress.name][progress.id] = progress
     end
 
-    def unregister(name, id: id)
+    def unregister(name, id:)
       return true if @progresses.nil? || @progresses[name].nil?
       @progresses[name][id] = nil
       true
@@ -44,7 +46,7 @@ class Progress
     end
 
     def file_for(name, id)
-      Ekylibre::Tenant.private_directory.join('tmp', 'imports', "#{name}-#{id}.progress")
+      Ekylibre::Tenant.private_directory.join('tmp', 'imports', "#{name.downcase.underscore}-#{id}.progress")
     end
 
     private
@@ -57,7 +59,7 @@ class Progress
     end
 
     def registration(name, id)
-      unregister(name, id: id)
+      unregister(name, id: id) unless File.exists?(file_for(name, id))
       @progresses &&
         @progresses[name.underscore] &&
         @progresses[name.underscore][id]
@@ -115,6 +117,6 @@ class Progress
   private
 
   def no_read_only!
-    raise 'Can\'t perform operation for read-only progress.' if read_only?
+    raise ReadOnlyError if read_only?
   end
 end

--- a/lib/progress.rb
+++ b/lib/progress.rb
@@ -5,8 +5,9 @@ class Progress
   attr_reader :id
 
   PRECISION = 3
+  DEFAULT_ID = 0
 
-  def initialize(name, id:, max: 100)
+  def initialize(name, id: DEFAULT_ID, max: 100)
     @name = name.underscore
     @id = id
     @max = max
@@ -19,13 +20,13 @@ class Progress
       @progresses[progress.name][progress.id] = progress
     end
 
-    def unregister(name, id:)
+    def unregister(name, id: DEFAULT_ID)
       return true if @progresses.nil? || @progresses[name].nil?
       @progresses[name][id] = nil
       true
     end
 
-    def fetch(name, id:)
+    def fetch(name, id: DEFAULT_ID)
       registration(name, id) || fetch!(name, id: id)
     end
 
@@ -51,7 +52,7 @@ class Progress
 
     private
 
-    def fetch!(name, id:)
+    def fetch!(name, id: DEFAULT_ID)
       return nil unless File.exists?(file_for(name, id))
       build(name, id: id).tap do |prog|
         prog.read_only!

--- a/lib/progress.rb
+++ b/lib/progress.rb
@@ -75,7 +75,7 @@ class Progress
     return 0 unless counting?
     magnitude = 10**PRECISION
     value = File.read(progress_file).to_f
-    return value unless percentage
+    return value.to_f/100*@max.to_f unless percentage && @max
     (value * magnitude).round / magnitude.to_f
   rescue
     0

--- a/lib/progress.rb
+++ b/lib/progress.rb
@@ -103,8 +103,9 @@ class Progress
   end
 
   def increment!
-    @value ||= value
-    set_value(@value + 1)
+    @value ||= value/100.0*4.0
+    @value += 1
+    self.value = @value
   end
 
   def read_only!

--- a/lib/progress.rb
+++ b/lib/progress.rb
@@ -1,3 +1,6 @@
+# Progress class permits to monitor progression of process by
+# saving progress indicator value outside of an ActiveRecord transaction
+# in order to permit asynchronous access to the information
 class Progress
   class ReadOnlyError < RuntimeError; end
 

--- a/lib/progress.rb
+++ b/lib/progress.rb
@@ -1,5 +1,5 @@
 class Progress
-  class ReadOnlyError < Exception; end;
+  class ReadOnlyError < RuntimeError; end
 
   attr_reader :name
   attr_reader :id
@@ -53,14 +53,12 @@ class Progress
     private
 
     def fetch!(name, id: DEFAULT_ID)
-      return nil unless File.exists?(file_for(name, id))
-      build(name, id: id).tap do |prog|
-        prog.read_only!
-      end
+      return nil unless File.exist?(file_for(name, id))
+      build(name, id: id).tap(&:read_only!)
     end
 
     def registration(name, id)
-      unregister(name, id: id) unless File.exists?(file_for(name, id))
+      unregister(name, id: id) unless File.exist?(file_for(name, id))
       @progresses &&
         @progresses[name.underscore] &&
         @progresses[name.underscore][id]
@@ -75,7 +73,7 @@ class Progress
     return 0 unless counting?
     magnitude = 10**PRECISION
     value = File.read(progress_file).to_f
-    return value.to_f/100*@max.to_f unless percentage && @max
+    return value.to_f / 100 * @max.to_f unless percentage && @max
     (value * magnitude).round / magnitude.to_f
   rescue
     0
@@ -106,7 +104,7 @@ class Progress
   end
 
   def increment!
-    @value ||= (value/100.0*@max.to_f)
+    @value ||= (value / 100.0 * @max.to_f)
     @value += 1
     self.value = @value
   end

--- a/lib/progress.rb
+++ b/lib/progress.rb
@@ -71,10 +71,12 @@ class Progress
     File.exist?(progress_file)
   end
 
-  def value
+  def value(percentage: true)
     return 0 unless counting?
     magnitude = 10**PRECISION
-    (File.read(progress_file).to_f * magnitude).round / magnitude.to_f
+    value = File.read(progress_file).to_f
+    return value unless percentage
+    (value * magnitude).round / magnitude.to_f
   rescue
     0
   end
@@ -82,9 +84,10 @@ class Progress
   def value=(value)
     no_read_only!
     self.class.register(self)
-    @value = value.to_f / @max.to_f * 100
+    @value = value.to_f
+    percentage = value.to_f / @max.to_f * 100
     FileUtils.mkdir_p(progress_file.dirname)
-    File.write(progress_file, @value.to_s)
+    File.write(progress_file, percentage.to_s)
   end
   alias set_value value=
 
@@ -103,7 +106,7 @@ class Progress
   end
 
   def increment!
-    @value ||= value/100.0*4.0
+    @value ||= (value/100.0*@max.to_f)
     @value += 1
     self.value = @value
   end

--- a/test/lib/progress_test.rb
+++ b/test/lib/progress_test.rb
@@ -1,16 +1,20 @@
 require 'test_helper'
 
 class ProgressTest < ActiveSupport::TestCase
+  setup do
+    FileUtils.rm_rf(Dir.glob(Ekylibre::Tenant.private_directory.join('tmp', 'imports', '*.progress')))
+  end
+
   test 'progresses can be set values that can then be consulted later' do
     progress = Progress.new('Example', id: 1)
-    progress.set_value(2)
+    progress.value = 2
 
     assert_equal 2, progress.value
   end
 
   test 'progresses\' values are set as a percentage from a specifiable max value' do
     progress = Progress.new('Not 100', id: 1, max: 40)
-    progress.set_value(3)
+    progress.value = 3
 
     assert_equal 7.5, progress.value
   end
@@ -32,7 +36,7 @@ class ProgressTest < ActiveSupport::TestCase
 
     assert_not_equal first, second
 
-    first.set_value(1)
+    first.value = 1
 
     assert_not_equal 1, second.value
     assert_equal 0, second.value
@@ -44,7 +48,7 @@ class ProgressTest < ActiveSupport::TestCase
 
     assert_not_equal first, second
 
-    first.set_value(1)
+    first.value = 1
 
     assert_not_equal 1, second.value
     assert_equal 0, second.value
@@ -56,15 +60,15 @@ class ProgressTest < ActiveSupport::TestCase
 
     assert_equal initialized, fetched
 
-    Progress.new('Not stored', id: 1).set_value(2)
+    Progress.new('Not stored', id: 1).value = 2
     fetched = Progress.fetch('Not stored', id: 1)
 
     assert_equal 2, fetched.value
   end
 
-  test 'progresses aren\'t reachabloe anymore once they have been cleared' do
+  test 'progresses aren\'t reachable anymore once they have been cleared' do
     progress = Progress.new('To be cleared', id: 1)
-    progress.set_value(2)
+    progress.value = 2
     progress.clear!
 
     assert_nil Progress.fetch('To be cleared', id: 1)
@@ -72,17 +76,17 @@ class ProgressTest < ActiveSupport::TestCase
 
   test 'cleared progresses are fetchable again if they are re-used' do
     progress = Progress.new('Lazarus', id: 1)
-    progress.set_value(2)
+    progress.value = 2
     progress.clear!
 
-    progress.set_value(1) # Rise and walk
+    progress.value = 1 # Rise and walk
 
     assert_equal 1, progress.value
   end
 
   test 'cleared progresses have 0 value' do
     progress = Progress.new('Zero', id: 1)
-    progress.set_value(2)
+    progress.value = 2
     progress.clear!
 
     assert_equal 0, progress.value

--- a/test/lib/progress_test.rb
+++ b/test/lib/progress_test.rb
@@ -115,4 +115,21 @@ class ProgressTest < ActiveSupport::TestCase
     assert_equal 5, read_only_ext.value
     assert read_only_ext.read_only?
   end
+
+  test 'progress#increment! is able to handle non-100 @maxs' do
+    lil_max = Progress.new('Little Max', max: 4)
+    lil_max.increment!
+    lil_max.increment!
+    lil_max.increment!
+
+    assert_equal 75, lil_max.value
+  end
+
+  test 'progress value can be expressed as a direct value (no percentage)' do
+    weird_max = Progress.new('Not 100', max: 5)
+    weird_max.value = 1
+
+    assert_equal 20, weird_max.value
+    assert_equal  1, weird_max.value(percentage: false)
+  end
 end

--- a/test/lib/progress_test.rb
+++ b/test/lib/progress_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class ProgressTest < ActiveSupport::TestCase
   setup do
     FileUtils.rm_rf(Dir.glob(Ekylibre::Tenant.private_directory.join('tmp', 'imports', '*.progress')))
+    Progress.instance_variable_set(:@progresses, nil)
   end
 
   test 'progresses can be set values that can then be consulted later' do
@@ -126,7 +127,7 @@ class ProgressTest < ActiveSupport::TestCase
   end
 
   test 'progress value can be expressed as a direct value (no percentage)' do
-    weird_max = Progress.new('Not 100', max: 5)
+    weird_max = Progress.new('Direct', max: 5)
     weird_max.value = 1
 
     assert_equal 20, weird_max.value

--- a/test/lib/progress_test.rb
+++ b/test/lib/progress_test.rb
@@ -6,21 +6,21 @@ class ProgressTest < ActiveSupport::TestCase
   end
 
   test 'progresses can be set values that can then be consulted later' do
-    progress = Progress.new('Example', id: 1)
+    progress = Progress.new('Example')
     progress.value = 2
 
     assert_equal 2, progress.value
   end
 
   test 'progresses\' values are set as a percentage from a specifiable max value' do
-    progress = Progress.new('Not 100', id: 1, max: 40)
+    progress = Progress.new('Not 100', max: 40)
     progress.value = 3
 
     assert_equal 7.5, progress.value
   end
 
   test 'progresses can be incremented rather than be set to a specific value' do
-    progress = Progress.new('Step by step', id: 1)
+    progress = Progress.new('Step by step')
     progress.increment!
 
     assert_equal 1, progress.value
@@ -30,7 +30,7 @@ class ProgressTest < ActiveSupport::TestCase
     assert_equal 2, progress.value
   end
 
-  test 'progresses with different ids are separate' do
+  test 'progresses can be specified ids to be kept separate in case of possible similar progresses running' do
     first  = Progress.new('Test', id: 1)
     second = Progress.new('Test', id: 2)
 
@@ -43,8 +43,8 @@ class ProgressTest < ActiveSupport::TestCase
   end
 
   test 'progresses with different names are separate' do
-    first  = Progress.new('First',  id: 1)
-    second = Progress.new('Second', id: 1)
+    first  = Progress.new('First')
+    second = Progress.new('Second')
 
     assert_not_equal first, second
 
@@ -55,27 +55,27 @@ class ProgressTest < ActiveSupport::TestCase
   end
 
   test 'progresses can be fetched back after creation' do
-    initialized = Progress.new('Initialized', id: 1)
-    fetched = Progress.fetch('Initialized', id: 1)
+    initialized = Progress.new('Initialized')
+    fetched = Progress.fetch('Initialized')
 
     assert_equal initialized, fetched
 
-    Progress.new('Not stored', id: 1).value = 2
-    fetched = Progress.fetch('Not stored', id: 1)
+    Progress.new('Not stored').value = 2
+    fetched = Progress.fetch('Not stored')
 
     assert_equal 2, fetched.value
   end
 
   test 'progresses aren\'t reachable anymore once they have been cleared' do
-    progress = Progress.new('To be cleared', id: 1)
+    progress = Progress.new('To be cleared')
     progress.value = 2
     progress.clear!
 
-    assert_nil Progress.fetch('To be cleared', id: 1)
+    assert_nil Progress.fetch('To be cleared')
   end
 
   test 'cleared progresses are fetchable again if they are re-used' do
-    progress = Progress.new('Lazarus', id: 1)
+    progress = Progress.new('Lazarus')
     progress.value = 2
     progress.clear!
 
@@ -85,7 +85,7 @@ class ProgressTest < ActiveSupport::TestCase
   end
 
   test 'cleared progresses have 0 as value' do
-    progress = Progress.new('Zero', id: 1)
+    progress = Progress.new('Zero')
     progress.value = 2
     progress.clear!
 
@@ -93,7 +93,7 @@ class ProgressTest < ActiveSupport::TestCase
   end
 
   test 'progresses can be set to read_only which prevents the modification of the value' do
-    progress = Progress.new('Readonly', id: 1)
+    progress = Progress.new('Readonly')
     progress.value = 3
     progress.read_only!
 
@@ -105,11 +105,11 @@ class ProgressTest < ActiveSupport::TestCase
   end
 
   test 'fetch when a progress file exists but no Progress object instantiates a read-only progress' do
-    path_to_file = Ekylibre::Tenant.private_directory.join('tmp', 'imports', 'external-1.progress')
+    path_to_file = Ekylibre::Tenant.private_directory.join('tmp', 'imports', 'external-0.progress')
     FileUtils.mkdir_p(path_to_file.dirname)
     File.write(path_to_file, '5')
 
-    read_only_ext = Progress.fetch('External', id: 1)
+    read_only_ext = Progress.fetch('External')
 
     assert_not_nil read_only_ext, "Progress#fetch didn't find External."
     assert_equal 5, read_only_ext.value

--- a/test/lib/progress_test.rb
+++ b/test/lib/progress_test.rb
@@ -131,6 +131,6 @@ class ProgressTest < ActiveSupport::TestCase
     weird_max.value = 1
 
     assert_equal 20, weird_max.value
-    assert_equal  1, weird_max.value(percentage: false)
+    assert_equal 1,  weird_max.value(percentage: false)
   end
 end


### PR DESCRIPTION
Progress now should be multi-process capable (not yet able to handle concurrent writes but there shouldn't be any because of a @read-only mechanism).

Fixed some other issues in the process, and overall made the library more robust and flexible.