### PR TITLE
Resolved error when you create intervention show the different type of interventions. Add block in method_missing

### DIFF
--- a/lib/nomen/record.rb
+++ b/lib/nomen/record.rb
@@ -2,8 +2,8 @@ module Nomen
   module Record
     class Base
       class << self
-        def method_missing(*args)
-          Nomen.find_or_initialize(name.tableize.gsub(/\Anomen\//, '')).send(*args)
+        def method_missing(*args, &block)
+          Nomen.find_or_initialize(name.tableize.gsub(/\Anomen\//, '')).send(*args, &block)
         end
 
         def respond_to?(method_name)


### PR DESCRIPTION
Added `&block` in `missing_method` in Nomen::Record so find_each can work properly again.