### PR TITLE
Fixed silent blocking error when creating multiple Fixed Assets with the same variant from a Purchase.

### DIFF
--- a/app/models/purchase_item.rb
+++ b/app/models/purchase_item.rb
@@ -198,7 +198,7 @@ class PurchaseItem < Ekylibre::Record::Base
     }
     asset_name = parcel_items.collect(&:name).to_sentence if products.any?
     asset_name ||= name
-    name_duplicate_count = FixedAsset.where(name: asset_name).count
+    name_duplicate_count = FixedAsset.where("name ~ ?", "^#{Regexp.escape(name)} ?\\d*$").count
     unless name_duplicate_count.zero?
       unique_identifier = (name_duplicate_count + 1).to_s(36).upcase
       asset_name = "#{asset_name} #{unique_identifier}"


### PR DESCRIPTION
Invoicing the parcel would fail silently if you created more than 2 assets with the same variant in the Purchase.

It created "Variant Asset" then "Variant Asset 1" then would try to create "Variant Asset 1" again for all the following assets instead of 2, 3, 4...