### PR TITLE
Removed start intervention form on each crumb to prevent timeout on intervention_participations index

### DIFF
--- a/app/views/backend/intervention_participations/index.html.haml
+++ b/app/views/backend/intervention_participations/index.html.haml
@@ -16,7 +16,7 @@
         end
         popup_content << { label: Crumb.human_attribute_name(:read_at), value: crumb.read_at.l }
         unless crumb.start? or crumb.stop?
-          popup_content << render('form', crumb: crumb)
+          # popup_content << render('form', crumb: crumb)
         end
         {
           name:         name,

--- a/app/views/backend/intervention_participations/index.html.haml
+++ b/app/views/backend/intervention_participations/index.html.haml
@@ -15,9 +15,9 @@
           popup_content << { label: Crumb.human_attribute_name(:nature), value: crumb.nature }
         end
         popup_content << { label: Crumb.human_attribute_name(:read_at), value: crumb.read_at.l }
-        unless crumb.start? or crumb.stop?
-          # popup_content << render('form', crumb: crumb)
-        end
+        # unless crumb.start? || crumb.stop?
+        #   popup_content << render('form', crumb: crumb)
+        # end
         {
           name:         name,
           shape:        crumb.geolocation,


### PR DESCRIPTION
Temporary solution: commented form displayed on each crumb
Next step: use a modal to prevent timeout while keeping the form
Answer to #2078 