### PR TITLE
Fix major issue in Sequence management code.

### DIFF
--- a/app/concepts/sequence_manager.rb
+++ b/app/concepts/sequence_manager.rb
@@ -31,20 +31,22 @@ class SequenceManager
     value
   end
 
+  def unique_reliable
+    value = sequence.next_value!
+    value = sequence.next_value! while @managed.find_by(@column => value)
+    value
+  end
+
   def load_predictable_into(record)
-    return true if @force && number_of(record).present?
+    return true unless @force || number_of(record).nil?
     set_number(record, unique_predictable)
     true
   end
 
   def load_reliable_into(record)
-    return true if !@force && number_of(record)
-
+    return true unless @force || number_of(record).nil?
     return load_predictable_into(record) unless sequence
-
-    value = sequence.next_value!
-    value = sequence.next_value! while @managed.find_by(@column => value)
-    set_number(record, value)
+    set_number(record, unique_reliable)
     true
   end
 

--- a/app/concepts/sequence_manager.rb
+++ b/app/concepts/sequence_manager.rb
@@ -1,5 +1,7 @@
 class SequenceManager
   def initialize(klass, options)
+    options = { force: true }.merge(options)
+
     @managed  = klass
 
     @start    = options[:start]


### PR DESCRIPTION
Current behavior:

>   Sequence of model is at number N
>   In DB last number of record is N+5

>   Record 1 is created : SequenceManager prefills it with N
>   SequenceManager tests existence of N, N+1, N+2, N+3, N+4, N+5, N+6
>   SequenceManager sets record with number N+6
 
>  Record 2 is created :  SequenceManager prefills it with N
>  SequenceManager tests existence of N, N+1, N+2, N+3, N+4, N+5, N+6, N+7
>  SequenceManager sets record with number N+7

>  Rinse and repeat.

As time goes and records are inserted, the setting of the number becomes longer and longer, checking more and more existing numbers.

After examination it appears that in the original design of ActsAsNumbered, the `:force ` option was set to true by default (the check being explicitly on `false`, making the `nil` default value act as a de-facto `true`).
This behavior was lost in my rework of the library in c1ed4ee. This behavior as been reintroduced, fixing the issue described above.

This fix should be self-sufficient to resynchronize the sequences of affected instances, the synchronization happening at the first call to `load_reliable_number_into` (so at first validations performed on a record using the sequence), making that first call heavier than usual while it catches up but ensuring subsequent calls go on properly.