### PR TITLE
Solve travis Bundle issue

### DIFF
--- a/test/ci/before_install
+++ b/test/ci/before_install
@@ -16,7 +16,7 @@ echo""
 echo "Dependencies install..."
 echo""
 sudo apt-get install -f -qq postgresql-9.6-postgis-2.3 graphicsmagick tesseract-ocr tesseract-ocr-fra tesseract-ocr-eng tesseract-ocr-spa pdftk libreoffice poppler-utils poppler-data qt5-default libqt5webkit5-dev gstreamer1.0-x gstreamer1.0-tools gstreamer1.0-plugins-base
-gem uninstall bundler -a && gem install bundler -v 1.14.6
+gem uninstall bundler -a -x && gem install bundler -v 1.14.6
 echo ""
 echo "Dependencies installed!"
 echo ""

--- a/test/ci/before_install
+++ b/test/ci/before_install
@@ -16,7 +16,7 @@ echo""
 echo "Dependencies install..."
 echo""
 sudo apt-get install -f -qq postgresql-9.6-postgis-2.3 graphicsmagick tesseract-ocr tesseract-ocr-fra tesseract-ocr-eng tesseract-ocr-spa pdftk libreoffice poppler-utils poppler-data qt5-default libqt5webkit5-dev gstreamer1.0-x gstreamer1.0-tools gstreamer1.0-plugins-base
-
+gem uninstall bundler -a && gem install bundler -v 1.14.6
 echo ""
 echo "Dependencies installed!"
 echo ""


### PR DESCRIPTION
Bundle is currently failing on travis due to a dependency error that happens on Bundler 1.15.x. This PR retrogrades it back to Bundler 1.14.6.