### PR TITLE
Entries continuous number fixes

### DIFF
--- a/app/controllers/backend/draft_journals_controller.rb
+++ b/app/controllers/backend/draft_journals_controller.rb
@@ -57,6 +57,7 @@ module Backend
       else
         count = journal_entries.count
         JournalEntry.transaction do
+          ActiveRecord::Base.connection.execute('LOCK journal_entries IN ACCESS EXCLUSIVE MODE')
           journal_entries.update_all(state: :confirmed, validated_at: Time.zone.now)
           JournalEntryItem.where(entry_id: journal_entries).update_all(state: :confirmed)
         end

--- a/db/migrate/20171129091817_add_continuous_number_to_journal_entries.rb
+++ b/db/migrate/20171129091817_add_continuous_number_to_journal_entries.rb
@@ -4,13 +4,11 @@ class AddContinuousNumberToJournalEntries < ActiveRecord::Migration
     reversible do |d|
       d.up do
         execute <<-SQL
-          CREATE SEQUENCE journal_entries_continuous_number;
-
           CREATE FUNCTION compute_journal_entry_continuous_number() RETURNS TRIGGER
             LANGUAGE plpgsql
             AS $$
             BEGIN
-              NEW.continuous_number := NEXTVAL('journal_entries_continuous_number');
+              NEW.continuous_number := (SELECT (COALESCE(MAX(continuous_number),0)+1) FROM journal_entries);
               RETURN NEW;
             END
             $$;

--- a/db/migrate/20171130092234_add_validated_at_to_journal_entries.rb
+++ b/db/migrate/20171130092234_add_validated_at_to_journal_entries.rb
@@ -1,5 +1,0 @@
-class AddValidatedAtToJournalEntries < ActiveRecord::Migration
-  def change
-    add_column :journal_entries, :validated_at, :datetime
-  end
-end

--- a/db/migrate/20171211091817_add_continuous_number_and_validated_at_to_journal_entries.rb
+++ b/db/migrate/20171211091817_add_continuous_number_and_validated_at_to_journal_entries.rb
@@ -1,6 +1,7 @@
-class AddContinuousNumberToJournalEntries < ActiveRecord::Migration
+class AddContinuousNumberAndValidatedAtToJournalEntries < ActiveRecord::Migration
   def change
     add_column :journal_entries, :continuous_number, :integer
+    add_column :journal_entries, :validated_at, :datetime
     reversible do |d|
       d.up do
         execute <<-SQL

--- a/db/migrate/20171211091817_add_continuous_number_and_validated_at_to_journal_entries.rb
+++ b/db/migrate/20171211091817_add_continuous_number_and_validated_at_to_journal_entries.rb
@@ -1,6 +1,7 @@
 class AddContinuousNumberAndValidatedAtToJournalEntries < ActiveRecord::Migration
   def change
     add_column :journal_entries, :continuous_number, :integer
+    add_index :journal_entries, :continuous_number, unique: true
     add_column :journal_entries, :validated_at, :datetime
     reversible do |d|
       d.up do
@@ -29,7 +30,6 @@ class AddContinuousNumberAndValidatedAtToJournalEntries < ActiveRecord::Migratio
       end
       d.down do
         execute <<-SQL
-          DROP SEQUENCE journal_entries_continuous_number;
           DROP TRIGGER compute_journal_entries_continuous_number_on_update ON journal_entries;
           DROP TRIGGER compute_journal_entries_continuous_number_on_insert ON journal_entries;
           DROP FUNCTION compute_journal_entry_continuous_number();


### PR DESCRIPTION
* Merge `JournalEntries#validated_at` migration with `JournalEntries#continuous_number`
* Use last `JournalEntries#continuous_number` to compute the new one to prevent gaps with rollback