### PR TITLE
Fix wrong amount when creating Purchase from Parcel

### DIFF
--- a/app/models/parcel.rb
+++ b/app/models/parcel.rb
@@ -493,7 +493,7 @@ class Parcel < Ekylibre::Record::Base
           parcel.items.order(:id).each do |item|
             next unless item.variant.purchasable? && item.population && item.population > 0
             catalog_item = Catalog.by_default!(:purchase).items.find_by(variant: item.variant)
-            unit_pretax_amount = item.pretax_amount.zero? ? nil : item.pretax_amount
+            unit_pretax_amount = item.unit_pretax_amount.zero? ? nil : item.unit_pretax_amount
             tax = Tax.current.first
             # check all taxes included to build unit_pretax_amount and tax from catalog with all taxes included
             if catalog_item && catalog_item.all_taxes_included

--- a/test/models/parcel_test.rb
+++ b/test/models/parcel_test.rb
@@ -224,6 +224,19 @@ class ParcelTest < ActiveSupport::TestCase
     assert_operator 0, :<, jei_s.real_credit.to_i
   end
 
+  test 'convert to purchase should have the correct amount' do
+    v = ProductNatureVariant.import_from_nomenclature(:fungicide, true)
+    to_recieve = [{
+        unit_pretax_amount: 10,
+        quantity: 10,
+        variant: v
+                  }]
+    parcel = new_parcel(items_attributes: to_recieve)
+    purchase = Parcel.convert_to_purchase [parcel]
+
+    assert_equal 100.to_d, purchase.amount
+  end
+
   test 'unitary items in parcels' do
     unitary_variant = ProductNatureVariant.import_from_nomenclature(:female_adult_cow, true)
     unitary_variant.products.create!(


### PR DESCRIPTION
Parcel::convert_to_purchase: unit_pretax_amount should not be computed using pretax_amount