### PR TITLE
Added validators

### DIFF
--- a/app/validators/boolean_validator.rb
+++ b/app/validators/boolean_validator.rb
@@ -1,0 +1,7 @@
+class BooleanValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
+      record.errors.add(attribute, :invalid_boolean)
+    end
+  end
+end

--- a/app/validators/collection_validator.rb
+++ b/app/validators/collection_validator.rb
@@ -1,0 +1,11 @@
+class CollectionValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if value.nil? || !value.kind_of?(Array)
+      record.errors.add(attribute, :should_be_set)
+    elsif value.empty? && !options[:allow_empty]
+      record.errors.add(attribute, :child_missing)
+    elsif value.any?(&:invalid?)
+      record.errors.add(attribute, :invalid_child)
+    end
+  end
+end

--- a/test/validators/boolean_validator_test.rb
+++ b/test/validators/boolean_validator_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class BooleanValidatable
+  include ActiveModel::Validations
+  attr_accessor :bool
+
+  validates :bool, boolean: true
+end
+
+class BooleanValidatorTest < ActiveSupport::TestCase
+  setup do
+    @obj = BooleanValidatable.new
+  end
+
+  test 'boolean should be valid' do
+    @obj.bool = true
+    assert @obj.valid?
+
+    @obj.bool = false
+    assert@obj.valid?
+  end
+
+  test 'any other value is invalid' do
+    @obj.bool = ''
+    refute @obj.valid?
+
+    @obj.bool = nil
+    refute @obj.valid?
+
+    @obj.bool = []
+    refute @obj.valid?
+
+    @obj.bool = 42
+    refute @obj.valid?
+  end
+end

--- a/test/validators/collection_validator_test.rb
+++ b/test/validators/collection_validator_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class CollectionValidatable
+  include ActiveModel::Validations
+  attr_accessor :collection
+
+  validates :collection, collection: true
+end
+
+class CollectionNotEmptyValidatable
+  include ActiveModel::Validations
+  attr_accessor :collection
+
+  validates :collection, collection: {allow_empty: false}
+end
+
+class CollectionValidatorTest < ActiveSupport::TestCase
+  setup do
+    @obj = CollectionValidatable.new
+    @invalid = Object.new
+
+    def @invalid.invalid?
+      true
+    end
+
+    @valid = Object.new
+
+    def @valid.invalid?
+      false
+    end
+  end
+
+  test 'empty collection should be valid' do
+    @obj.collection = []
+
+    assert @obj.valid?
+  end
+
+  test 'valid if all elements in collection are valid' do
+    @obj.collection = [@valid]
+
+    assert @obj.valid?
+  end
+
+  test 'ivalid if any element is invalid' do
+    @obj.collection = [@valid, @invalid]
+
+    refute @obj.valid?
+  end
+
+  test 'allow_empty option' do
+    alo = CollectionNotEmptyValidatable.new
+    alo.collection = []
+    refute alo.valid?
+
+    alo.collection = [@valid]
+    assert alo.valid?
+  end
+end


### PR DESCRIPTION
Collection: enforce attribute to be Array and is valid only if children are valid
Boolean: syntactic sugar for 'include: {in: [true, false]}'