### PR TITLE
Added .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,5 @@ Procfile.*
 
 .byebug_history
 .gitconfig
+
+.DS_Store


### PR DESCRIPTION
This prevents people from accidentally adding the .DS_Store file.  (Yes, I have seen code bases containing .DS_Store files.)