### PR TITLE
Made ManageRestfully generate modules dynamically

### DIFF
--- a/app/controllers/concerns/restfully_manageable.rb
+++ b/app/controllers/concerns/restfully_manageable.rb
@@ -250,15 +250,7 @@ module RestfullyManageable
         end
       end
 
-      restful_module = Module.new
-      name_module(restful_module, '')
-      restful_module.class_eval(code)
-      restful_module.extend ActiveSupport::Concern
-      restful_module.send(:included) do
-        eval class_code
-      end
-      include restful_module
-      self
+      insert_module(code, class_code)
     end
 
     # Build standard actions to manage records of a model
@@ -298,15 +290,7 @@ module RestfullyManageable
       code << "end\n"
 
       # list = code.split("\n"); list.each_index{|x| puts((x+1).to_s.rjust(4)+": "+list[x])}
-      restful_module = Module.new
-      name_module(restful_module, :list)
-      restful_module.class_eval(code)
-      restful_module.extend ActiveSupport::Concern
-      restful_module.send(:included) do
-        eval class_code
-      end
-      include restful_module
-      self
+      insert_module(code, class_code, name: :list)
     end
 
     # Build standard actions to manage records of a model
@@ -348,16 +332,7 @@ module RestfullyManageable
       code << "  render 'pick'\n"
       code << "end\n"
 
-      restful_module = Module.new
-      # naming the module
-      name_module(restful_module, :incorporation)
-      restful_module.class_eval(code)
-      restful_module.extend ActiveSupport::Concern
-      restful_module.send(:included) do
-        eval class_code
-      end
-      include restful_module
-      self
+      insert_module(code, class_code, name: :incorporation)
     end
 
     #
@@ -375,15 +350,7 @@ module RestfullyManageable
       code << "  end\n"
       code << "end\n"
 
-      restful_module = Module.new
-      name_module(restful_module, :picture)
-      restful_module.class_eval(code)
-      restful_module.extend ActiveSupport::Concern
-      restful_module.send(:included) do
-        eval class_code
-      end
-      include restful_module
-      self
+      insert_module(code, class_code, name: :picture)
     end
 
     private
@@ -391,6 +358,18 @@ module RestfullyManageable
     def name_module(mod, kind)
       mod_name = "#{controller_name.classify}#{kind.to_s.classify}"
       RestfullyManageable.const_set mod_name, mod
+    end
+
+    def insert_module(code, class_code, name: '')
+      restful_module = Module.new
+      name_module(restful_module, name)
+      restful_module.class_eval(code)
+      restful_module.extend ActiveSupport::Concern
+      restful_module.send(:included) do
+        eval class_code
+      end
+      include restful_module
+      self
     end
   end
 end

--- a/app/controllers/concerns/restfully_manageable.rb
+++ b/app/controllers/concerns/restfully_manageable.rb
@@ -356,7 +356,11 @@ module RestfullyManageable
     private
 
     def name_module(mod, kind)
-      mod_name = "#{controller_name.classify}#{kind.to_s.classify}Actions"
+      # Ensure we don't collide with other controllers but still don't need
+      # intermediate namespacing modules
+      unique_controller_name = controller_path.camelize.simpleize
+      kind_name = kind.to_s.classify
+      mod_name = "#{unique_controller_name}#{kind_name}Actions"
       RestfullyManageable.const_set mod_name, mod
     end
 

--- a/app/controllers/concerns/restfully_manageable.rb
+++ b/app/controllers/concerns/restfully_manageable.rb
@@ -6,7 +6,7 @@ module RestfullyManageable
     def manage_restfully(defaults = {})
       name = controller_name
       path = controller_path
-      options = defaults.extract!(:t3e, :creation_t3e, :redirect_to, :xhr, :destroy_to, :subclass_inheritance, :partial, :multipart, :except, :only, :cancel_url, :scope, :identifier, :continue)
+      options = defaults.extract!(:t3e, :creation_t3e, :redirect_to, :xhr, :destroy_to, :subclass_inheritance, :partial, :multipart, :except, :only, :cancel_url, :scope, :identifier, :continue, :model_name)
       after_save_url    = options[:redirect_to]
       after_destroy_url = options[:destroy_to] || :index
       actions  = %i[index show new create edit update destroy]
@@ -14,7 +14,7 @@ module RestfullyManageable
       actions -= [options[:except]].flatten if options[:except]
 
       record_name = name.to_s.singularize
-      model_name  = name.to_s.classify
+      model_name  = options[:model_name] || name.to_s.classify
       model = model_name.constantize
       columns = model.columns_definition.keys
 

--- a/app/controllers/concerns/restfully_manageable.rb
+++ b/app/controllers/concerns/restfully_manageable.rb
@@ -356,7 +356,7 @@ module RestfullyManageable
     private
 
     def name_module(mod, kind)
-      mod_name = "#{controller_name.classify}#{kind.to_s.classify}"
+      mod_name = "#{controller_name.classify}#{kind.to_s.classify}Actions"
       RestfullyManageable.const_set mod_name, mod
     end
 

--- a/test/controllers/concerns/restfully_manageable_test.rb
+++ b/test/controllers/concerns/restfully_manageable_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class RestfullyManageableTest < ActionController::TestCase
+  Model = Class.new do
+    def self.columns_definition
+      { 'id' => "whatever" }
+    end
+  end
+
+  setup do
+    if defined? ModelController
+      RestfullyManageableTest.send :remove_const, :ModelController
+    end
+    if defined? RestfullyManageable::Model
+      RestfullyManageable.send :remove_const, :Model
+    end
+
+    class ModelController < ActionController::Base
+      include RestfullyManageable
+    end
+    @kontroller = ModelController.new
+  end
+
+  test 'restfully_manageable doesn\'t define the actions' do
+    initial_methods = ModelController.new.methods(false)
+    ModelController.send(:manage_restfully, only: :index, model_name: 'RestfullyManageableTest::Model')
+    after_restfully_methods = ModelController.new.methods(false)
+    assert_equal after_restfully_methods, initial_methods
+  end
+
+  test 'restfully_manageable inserts a new module in the controller' do
+    initial_parents = ModelController.ancestors
+    ModelController.send(:manage_restfully, only: :index, model_name: 'RestfullyManageableTest::Model')
+    after_restfully_parents = ModelController.ancestors
+    difference = after_restfully_parents - initial_parents
+    assert_equal difference.count, 1
+    assert_equal difference.first.class, Module
+  end
+
+  test 'restfully_manageable does define controller methods' do
+    controller = ModelController.new
+    assert_not controller.respond_to? :index
+    ModelController.send(:manage_restfully, only: :index, model_name: 'RestfullyManageableTest::Model')
+    assert controller.respond_to? :index
+  end
+end


### PR DESCRIPTION
This makes it so `manage_restfully`-generated methods can be overwritten and called through `super` instead of simply being overwritten when redefining:

Example:
```ruby
# Current behaviour
class MyController < ApplicationController
  manage_restfully only: :index

  def index
    Rails.log "Entering the index override"
    super # => NoMethodError: super: no superclass method `index' for `#<MyController:0x00007fbc5797fc78>
   end
end

# On PR
# Current behaviour
class MyController < ApplicationController
  manage_restfully only: :index

  def index
    Rails.log "Entering the index override"
    super # => returns index view
  end
end
```