### PR TITLE
fix postgres repository name

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3,7 +3,7 @@
 --
 
 -- Dumped from database version 13.3 (Debian 13.3-1.pgdg110+1)
--- Dumped by pg_dump version 13.5 (Debian 13.5-0+deb11u1)
+-- Dumped by pg_dump version 13.8 (Debian 13.8-0+deb11u1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -33,7 +33,7 @@ COPY . /eky
 COPY ./docker/dev/database.yml.sample /eky/config/database.yml
 
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" | tee  /etc/apt/sources.list.d/pgdg.list && \
+    echo "deb http://apt.postgresql.org/pub/repos/apt/ $(grep -oP 'VERSION_CODENAME=\K\w+' /etc/os-release)-pgdg main" | tee  /etc/apt/sources.list.d/pgdg.list && \
     apt-get update && \
     apt-get -y install --no-install-recommends postgresql-client-11 python3-pip git
 

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -17,7 +17,7 @@ RUN cp /app/docker/prod/build_config/application.yml /app/docker/prod/build_conf
 FROM registry.gitlab.com/ekylibre/docker-base-images/ruby${RUBY_VERSION}-prod:master AS rails
 
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" | tee  /etc/apt/sources.list.d/pgdg.list && \
+    echo "deb http://apt.postgresql.org/pub/repos/apt/ $(grep -oP 'VERSION_CODENAME=\K\w+' /etc/os-release)-pgdg main" | tee  /etc/apt/sources.list.d/pgdg.list && \
     apt-get update && \
     apt-get -y install --no-install-recommends postgresql-client-11 python3-pip && \
     pip3 install minio


### PR DESCRIPTION
After clone repository and run docker-compose up command got error 
` E: The repository 'http://apt.postgresql.org/pub/repos/apt stretch-pgdg Release' does not have a Release file.`
finding a solution led to [https://forum.getodk.org/t/central-service-image-build-fails-due-to-missing-stretch-pgdg-repository/39528](url)
Obviously, the problem is related to the tight binding to the database version. 
This solution worked for me.